### PR TITLE
Ignore passed consumers in allocation candidates

### DIFF
--- a/placement/objects/allocation_candidate.py
+++ b/placement/objects/allocation_candidate.py
@@ -132,7 +132,8 @@ class AllocationCandidates(object):
         candidates = {}
         for suffix, group in groups.items():
             rg_ctx = res_ctx.RequestGroupSearchContext(
-                context, group, rw_ctx.has_trees, sharing, suffix)
+                context, group, rw_ctx.has_trees, sharing, suffix,
+                rqparams.ignore_consumers)
 
             # Which resource classes are requested in more than one group?
             for rc in rg_ctx.rcs:
@@ -504,7 +505,8 @@ def _build_provider_summaries(context, rw_ctx, root_ids, prov_traits):
     #        'reserved': integer,
     #        'allocation_ratio': float,
     #    }
-    usages = res_ctx.get_usages_by_provider_trees(context, new_roots)
+    usages = res_ctx.get_usages_by_provider_trees(context, new_roots,
+                                                  rw_ctx.ignore_consumers)
 
     # Before we go creating provider summary objects, first grab all the
     # provider information (including root, parent and UUID information) for

--- a/placement/schemas/allocation_candidate.py
+++ b/placement/schemas/allocation_candidate.py
@@ -43,9 +43,12 @@ GET_SCHEMA_1_16['properties']['limit'] = {
     "minLength": 1
 }
 
-# Add required parameter.
+# Add required parameter and ignore_consumer parameter
 GET_SCHEMA_1_17 = copy.deepcopy(GET_SCHEMA_1_16)
 GET_SCHEMA_1_17['properties']['required'] = {
+    "type": ["string"]
+}
+GET_SCHEMA_1_17['properties']['ignore_consumer'] = {
     "type": ["string"]
 }
 


### PR DESCRIPTION
This commit makes it possible to pass a list of consumer UUIDs to ignore
when retrieven allocation candidates. This can be useful for
implementations replacing a VM on resize instead of copying it. Some
care has to be taken on the client side to not overbook the
resource-provider, but there's another check when trying to allocate the
resources that should make sure of that.