### PR TITLE
Use separate transaction in capacity check

### DIFF
--- a/placement/objects/allocation.py
+++ b/placement/objects/allocation.py
@@ -164,7 +164,7 @@ def _check_capacity_exceeded(ctx, allocs):
     # up-to-date usage value in case a racing request has
     # changed it after we began an outer transaction.
     with db_api.placement_context_manager.reader.independent.using(ctx):
-        records = ctx.session.execute(sel)
+        records = ctx.session.execute(sel).all()
     # Create a map keyed by (rp_uuid, res_class) for the records in the DB
     usage_map = {}
     provs_with_inv = set()

--- a/placement/objects/allocation.py
+++ b/placement/objects/allocation.py
@@ -107,6 +107,7 @@ def _check_capacity_exceeded(ctx, allocs):
     #    FROM allocations
     #    WHERE resource_class_id IN ($RESOURCE_CLASSES)
     #    AND resource_provider_id IN ($RESOURCE_PROVIDERS)
+    #    AND consumer_id NOT IN ($CONSUMERS)
     #    GROUP BY resource_provider_id, resource_class_id
     # ) AS allocs
     # ON inv.resource_provider_id = allocs.resource_provider_id
@@ -120,12 +121,14 @@ def _check_capacity_exceeded(ctx, allocs):
                   for a in allocs])
     provider_uuids = set([a.resource_provider.uuid for a in allocs])
     provider_ids = set([a.resource_provider.id for a in allocs])
+    consumer_uuids = {alloc.consumer.uuid for alloc in allocs}
     usage = sa.select([_ALLOC_TBL.c.resource_provider_id,
                        _ALLOC_TBL.c.resource_class_id,
                        sql.func.sum(_ALLOC_TBL.c.used).label('used')])
     usage = usage.where(
         sa.and_(_ALLOC_TBL.c.resource_class_id.in_(rc_ids),
-                _ALLOC_TBL.c.resource_provider_id.in_(provider_ids)))
+                _ALLOC_TBL.c.resource_provider_id.in_(provider_ids),
+                sa.not_(_ALLOC_TBL.c.consumer_id.in_(consumer_uuids))))
     usage = usage.group_by(_ALLOC_TBL.c.resource_provider_id,
                            _ALLOC_TBL.c.resource_class_id)
     usage = sa.alias(usage, name='usage')

--- a/placement/objects/allocation.py
+++ b/placement/objects/allocation.py
@@ -158,7 +158,13 @@ def _check_capacity_exceeded(ctx, allocs):
     sel = sel.where(
         sa.and_(_RP_TBL.c.id.in_(provider_ids),
                 _INV_TBL.c.resource_class_id.in_(rc_ids)))
-    records = ctx.session.execute(sel)
+    # NOTE(pas-ha): Use a separate database transaction to read
+    # the data because we might be wrapped in an outer
+    # database transaction when we reach here. We want to get an
+    # up-to-date usage value in case a racing request has
+    # changed it after we began an outer transaction.
+    with db_api.placement_context_manager.reader.independent.using(ctx):
+        records = ctx.session.execute(sel)
     # Create a map keyed by (rp_uuid, res_class) for the records in the DB
     usage_map = {}
     provs_with_inv = set()

--- a/placement/tests/fixtures.py
+++ b/placement/tests/fixtures.py
@@ -18,6 +18,7 @@
 
 
 from oslo_config import cfg
+from oslo_db.sqlalchemy import enginefacade
 from oslo_db.sqlalchemy import test_fixtures
 
 from placement.db.sqlalchemy import migration
@@ -43,6 +44,20 @@ class Database(test_fixtures.GeneratesSchema, test_fixtures.AdHocDbFixture):
         self.conf_fixture = conf_fixture
         self.get_engine = placement_db.get_placement_engine
         placement_db.configure(self.conf_fixture.conf)
+
+    def setUp(self):
+        super().setUp()
+        self.__orig_clone = enginefacade._TransactionContextManager._clone
+
+        def patched_clone(inner_self, **kwargs):
+            kwargs['independent'] = False
+            return self.__orig_clone(inner_self, **kwargs)
+
+        enginefacade._TransactionContextManager._clone = patched_clone
+
+    def cleanUp(self):
+        super().cleanUp()
+        enginefacade._TransactionContextManager._clone = self.__orig_clone
 
     def get_enginefacade(self):
         return placement_db.placement_context_manager

--- a/tools/reproduce_parallel_allocation.py
+++ b/tools/reproduce_parallel_allocation.py
@@ -1,0 +1,117 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from collections import Counter
+import threading
+import uuid
+
+import click
+import pyccloud
+
+
+class Bla(threading.Thread):
+
+    def __init__(self, *args, p, uuid_, signal, results, generation=None,
+                 **kwargs):
+        self._p = p
+        self._uuid = uuid_
+        self._signal = signal
+        self._results = results
+        self._generation = generation
+        super().__init__(*args, **kwargs)
+
+    def run(self):
+        requested_memory_mb = 120 * 1024
+
+        data = {
+            'allocations': {
+                'd29b6d53-af4a-4fd0-8f5a-149b600f9b59': {
+                    'resources': {
+                        'MEMORY_MB': requested_memory_mb,
+                    },
+                },
+            },
+            'consumer_generation': self._generation,
+            'user_id': '02613c7c5763fba364fc5cacdf5aca1d38fc'
+                       'f70bad0d8a52fe6e51d85c8147d1',
+            'project_id': '7db511c1805f4a7ba57abc822c7b8835',
+            'consumer_type': 'INSTANCE',
+        }
+
+        self._signal.wait()
+
+        resp = self._p.put(f"/allocations/{self._uuid}", json=data)
+        self._results.append((self._uuid, resp.status_code))
+        print(f"{resp.status_code}: {resp.text}")
+
+
+@click.command()
+def main():
+    N = 8
+    # which region do I fill up? qa-de-3 probably
+    ca = pyccloud.CloudAnalyzer.from_autoconf()
+
+    p = ca.os_admin.api.placement
+    p.default_microversion = 1.38
+
+    uuids = [str(uuid.uuid4()) for _ in range(N)]
+    print(uuids)
+
+    signal = threading.Barrier(N)
+    threads = []
+    results = []
+
+    for uuid_ in uuids:
+        # how to parallel? threads? processes? shell?
+        # let's try threads, all waiting for the same signal after start
+        t = Bla(p=p, uuid_=uuid_, signal=signal, results=results)
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join()
+
+    generations = {uuid_: 1 if status == 204 else None
+                   for uuid_, status in results}
+    print(Counter(r[1] for r in results))
+
+    for uuid_ in uuids:
+        print(uuid_)
+        print(p.get(f"/allocations/{uuid_}").json())
+
+    signal = threading.Barrier(N)
+    threads = []
+    results = []
+
+    for uuid_ in uuids:
+        # how to parallel? threads? processes? shell?
+        # let's try threads, all waiting for the same signal after start
+        t = Bla(p=p, uuid_=uuid_, signal=signal, results=results,
+                generation=generations[uuid_])
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join()
+
+    print(Counter(r[1] for r in results))
+
+    for uuid_ in uuids:
+        print(uuid_)
+        print(p.get(f"/allocations/{uuid_}").json())
+
+    if click.confirm('Delete them?'):
+        for uuid_ in uuids:
+            p.delete(f"/allocations/{uuid_}")
+
+
+if __name__ == '__main__':
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,14 @@
 [tox]
 minversion = 3.1.1
 envlist = py39,functional-py39,pep8
-skipsdist = True
-# Automatic envs (pyXX) will use the python version appropriate to that
-# env and ignore basepython inherited from [testenv]. That's what we
-# want, and we don't need to be warned about it.
-ignore_basepython_conflict = True
 
 [testenv]
-basepython = python3
 usedevelop = True
 whitelist_externals =
   bash
   rm
   env
-install_command = pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/yoga} {opts} {packages}
+install_command = python -I -m pip install -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master} {opts} {packages}
 setenv =
   VIRTUAL_ENV={envdir}
   LANGUAGE=en_US
@@ -30,7 +24,8 @@ deps = -r{toxinidir}/test-requirements.txt
 commands =
   stestr run {posargs}
 passenv =
-  OS_DEBUG GENERATE_HASHES
+  OS_DEBUG
+  GENERATE_HASHES
 # there is also secret magic in subunit-trace which lets you run in a fail only
 # mode. To do this define the TRACE_FAILONLY environmental variable.
 
@@ -56,6 +51,11 @@ commands =
 
 [testenv:functional-py39]
 envdir = {toxworkdir}/py39
+commands =
+  {[testenv:functional]commands}
+
+[testenv:functional-py310]
+envdir = {toxworkdir}/py310
 commands =
   {[testenv:functional]commands}
 
@@ -119,7 +119,7 @@ description =
 deps = -r{toxinidir}/doc/requirements.txt
 commands =
   rm -rf doc/build
-  sphinx-build -W -b html -d doc/build/doctrees doc/source doc/build/html
+  sphinx-build -W --keep-going -b html -j auto doc/source doc/build/html
   # Test the redirects
   whereto doc/build/html/.htaccess doc/test/redirect-tests.txt
 
@@ -173,9 +173,9 @@ max-complexity=19
 # system dependencies are missing, since it's used to tell you what system
 # dependencies are missing! This also means that bindep must be installed
 # separately, outside of the requirements files, and develop mode disabled
-# explicitly to avoid unnecessarily installing the checked-out repo too (this
-# further relies on "tox.skipsdist = True" above).
+# explicitly to avoid unnecessarily installing the checked-out repo too
 usedevelop = False
+skipsdist = True
 deps = bindep
 commands =
   bindep test

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-minversion = 3.1.1
+minversion = 3.18.0
 envlist = py39,functional-py39,pep8
 
 [testenv]
 usedevelop = True
-whitelist_externals =
+allowlist_externals =
   bash
   rm
   env
@@ -126,7 +126,7 @@ commands =
 [testenv:pdf-docs]
 basepython = python3
 deps = {[testenv:docs]deps}
-whitelist_externals =
+allowlist_externals =
   make
 commands =
   sphinx-build -W -b latex doc/source doc/build/pdf


### PR DESCRIPTION
without it, the retrying on concurrent update will use the same transaction, and, due to 'repeatable reads' transaction isolation, the check for capacity will not be able to read new usage data that was most probably updated in the concurrent update.

Closes-Bug: #2039560
Change-Id: Ia2d57e0f8b963a00d2f26c447f1d2fb0a108555e

---
This is a change [propose upstrea](https://review.opendev.org/c/openstack/placement/+/898808) which was tested in qa and seemed to fix the problem we had with overcommited resource providers.